### PR TITLE
Link to repository table in documentation repository (README change only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,33 +30,7 @@ To report such violations, please send an email to [corona-warn-app.opensource@s
 
 ## Repositories
 
-| Repository                | Description                                                                  |
-| ------------------------- | ---------------------------------------------------------------------------- |
-| [cwa-documentation]       | Project overview, general documentation, and white papers.                   |
-| [cwa-app-ios]             | Native iOS app using the Apple/Google exposure notification API.             |
-| [cwa-app-android]         | Native Android app using the Apple/Google exposure notification API.         |
-| [cwa-wishlist]            | Community feature requests.                                                  |
-| [cwa-website]             | The official website for the Corona-Warn-App.                                |
-| [cwa-server]              | Backend implementation for the Apple/Google exposure notification API.       |
-| [cwa-ppa-server]          | Backend implementation for the privacy-preserving analytics server.          |
-| [cwa-verification-server] | Backend implementation of the verification process.                          |
-| [cwa-verification-portal] | The portal to interact with the verification server.                         |
-| [cwa-verification-iam]    | The identity and access management to interact with the verification server. |
-| [cwa-testresult-server]   | Receives the test results from connected laboratories.                       |
-| [cwa-log-upload]          | The log upload service is the counterpart of the log upload in the app.      |
-
-[cwa-documentation]: https://github.com/corona-warn-app/cwa-documentation
-[cwa-app-ios]: https://github.com/corona-warn-app/cwa-app-ios
-[cwa-app-android]: https://github.com/corona-warn-app/cwa-app-android
-[cwa-wishlist]: https://github.com/corona-warn-app/cwa-wishlist
-[cwa-website]: https://github.com/corona-warn-app/cwa-website
-[cwa-server]: https://github.com/corona-warn-app/cwa-server
-[cwa-ppa-server]: https://github.com/corona-warn-app/cwa-ppa-server
-[cwa-verification-server]: https://github.com/corona-warn-app/cwa-verification-server
-[cwa-verification-portal]: https://github.com/corona-warn-app/cwa-verification-portal
-[cwa-verification-iam]: https://github.com/corona-warn-app/cwa-verification-iam
-[cwa-testresult-server]: https://github.com/corona-warn-app/cwa-testresult-server
-[cwa-log-upload]: https://github.com/corona-warn-app/cwa-log-upload
+A list of all public repositories from the Corona-Warn-App can be found [here](https://github.com/corona-warn-app/cwa-documentation/blob/master/README.md#repositories).
 
 ## Licensing
 


### PR DESCRIPTION
This PR discontinues the [repository table](https://github.com/corona-warn-app/cwa-wishlist#repositories) in the README here, instead the README now links to the [table](https://github.com/corona-warn-app/cwa-documentation/blob/master/README.md#repositories) in the [documentation repository](https://github.com/corona-warn-app/cwa-documentation).
This will make it easier to update the list with newly created repositories.