### PR TITLE
Link to overview issues in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/01_feature_request.md
@@ -8,6 +8,8 @@ labels: feature request
 Thanks for requesting a feature 🙌 ❤️
 
 Before opening a new issue, please make sure that we do not have any duplicates already open. You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead.
+
+To browse existing issues by category, please see these overview issues: https://github.com/corona-warn-app/cwa-wishlist/issues/337
 -->
 
 ## Feature description

--- a/.github/ISSUE_TEMPLATE/02_enhancement.md
+++ b/.github/ISSUE_TEMPLATE/02_enhancement.md
@@ -8,6 +8,8 @@ labels: enhancement
 Thanks for proposing an enhancement 🙌 ❤️
 
 Before opening a new issue, please make sure that we do not have any duplicates already open. You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead.
+
+To browse existing issues by category, please see these overview issues: https://github.com/corona-warn-app/cwa-wishlist/issues/337
 -->
 
 

--- a/.github/ISSUE_TEMPLATE/03_additional_country.md
+++ b/.github/ISSUE_TEMPLATE/03_additional_country.md
@@ -9,4 +9,6 @@ Thanks for proposing an an additional country to publish the app to. 🙌 ❤️
 
 Before opening a new issue, please make sure that we do not have any duplicates already open. You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead.
 Just note the country in the issue title.
+
+Existing issues in this category can be looked at here: https://github.com/corona-warn-app/cwa-wishlist/labels/Country
 -->

--- a/.github/ISSUE_TEMPLATE/04_documentation_enhancement.md
+++ b/.github/ISSUE_TEMPLATE/04_documentation_enhancement.md
@@ -8,6 +8,10 @@ labels: documentation, enhancement
 Thanks for pointing us to missing information 🙌 ❤️
 
 Before opening a new issue, please make sure that we do not have any duplicates already open. You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead.
+
+To browse existing issues by category, please see these overview issues: https://github.com/corona-warn-app/cwa-wishlist/issues/337
+
+Specifically, please check if your suggestion has already been raised here: https://github.com/corona-warn-app/cwa-wishlist/issues/394
 -->
 
 ## What is missing


### PR DESCRIPTION
Users might not be able to find a duplicate issue when searching for the keywords they have in mind in case that other, similar words were used to describe the same issue. For this reason, it would be a good idea to link users to the appropriate place to browse issues by category depending on which kind of issue they are about to open.

* For feature requests and enhancements, the overview overview issue (#337) should be linked.
* For country requests, the search by Country tag should be linked.
* For documentation requests, the overview overview as well as the overview #394 should be linked.