### PR TITLE
Update to README documenting process to add fix-version labels instead of using cwa-backlog (closes #380)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This repository is a place that shall give community members the opportunity to 
 
 The repository does not contain any code. The [issue tracker](https://github.com/corona-warn-app/cwa-wishlist/issues) contains ideas for new features or enhancements of existing ones.
 
-Issues will be scanned regularly by members of the CWA Github organization and discussed with the product management and the RKI. If an issues is selected to be implemented in a future release of the Corona-Warn-App, it will be moved to the [CWA Backlog Repository](https://github.com/corona-warn-app/cwa-backlog).
+Issues will be scanned regularly by members of the CWA GitHub organization and discussed with the product management and the RKI. If it is decided to fix an issue or to implement a suggestion from an issue then the issue will be marked up in the originating repository (including in this one) using a label "Fix" + release number. This means that the issue will have a corresponding internal development status which is one of OPEN, ANALYZING, IN PROGRESS, COMPLETED, or CONFIRMED (i.e. tested). The Fix label stays with the issue even after the fix or enhancement has been released and the issue has been closed.
+
+(Note: Originally the [CWA Backlog Repository](https://github.com/corona-warn-app/cwa-backlog) was used to track planned fixes and enhancements. All items from that repository have been redistributed and the now empty [CWA Backlog Repository](https://github.com/corona-warn-app/cwa-backlog) was put into archive status on March 30th, 2021.)"
 
 ## How to find existing ideas
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The repository does not contain any code. The [issue tracker](https://github.com
 
 Issues will be scanned regularly by members of the CWA GitHub organization and discussed with the product management and the RKI. If it is decided to fix an issue or to implement a suggestion from an issue then the issue will be marked up in the originating repository (including in this one) using a label "Fix" + release number. This means that the issue will have a corresponding internal development status which is one of OPEN, ANALYZING, IN PROGRESS, COMPLETED, or CONFIRMED (i.e. tested). The Fix label stays with the issue even after the fix or enhancement has been released and the issue has been closed.
 
-(Note: Originally the [CWA Backlog Repository](https://github.com/corona-warn-app/cwa-backlog) was used to track planned fixes and enhancements. All items from that repository have been redistributed and the now empty [CWA Backlog Repository](https://github.com/corona-warn-app/cwa-backlog) was put into archive status on March 30th, 2021.)"
+(Note: Originally the [CWA Backlog Repository](https://github.com/corona-warn-app/cwa-backlog) was used to track planned fixes and enhancements. All items from that repository have been redistributed and the now empty [CWA Backlog Repository](https://github.com/corona-warn-app/cwa-backlog) was put into archive status on March 30th, 2021.)
 
 ## How to find existing ideas
 


### PR DESCRIPTION
This PR implements the text discussed and agreed in "Showing items planned for implementation" #380.

The repository's [README.md](https://github.com/corona-warn-app/cwa-wishlist/blob/master/README.md) explains how the [cwa-backlog](https://github.com/corona-warn-app/cwa-backlog) repository is no longer used to list items which are planned for implementation. Instead, any item planned for implementation will be tagged with a GitHub label consisting for "Fix" + <release_number> , for instance, [Fix 2.0](https://github.com/corona-warn-app/cwa-wishlist/labels/Fix%202.0).

The section updated [Structure](https://github.com/corona-warn-app/cwa-wishlist#structure) section will read as follows:

---

## Structure

The repository does not contain any code. The [issue tracker](https://github.com/corona-warn-app/cwa-wishlist/issues) contains ideas for new features or enhancements of existing ones.

Issues will be scanned regularly by members of the CWA GitHub organization and discussed with the product management and the RKI. If it is decided to fix an issue or to implement a suggestion from an issue then the issue will be marked up in the originating repository (including in this one) using a label "Fix" + release number. This means that the issue will have a corresponding internal development status which is one of OPEN, ANALYZING, IN PROGRESS, COMPLETED, or CONFIRMED (i.e. tested). The Fix label stays with the issue even after the fix or enhancement has been released and the issue has been closed.

(Note: Originally the [CWA Backlog Repository](https://github.com/corona-warn-app/cwa-backlog) was used to track planned fixes and enhancements. All items from that repository have been redistributed and the now empty [CWA Backlog Repository](https://github.com/corona-warn-app/cwa-backlog) was put into archive status on March 30th, 2021.)