### PR TITLE
Bump copyright year in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ A list of all public repositories from the Corona-Warn-App can be found [here](h
 
 ## Licensing
 
-Copyright (c) 2020 Deutsche Telekom AG and SAP SE or an SAP affiliate company.
+Copyright (c) 2020-2021 Deutsche Telekom AG and SAP SE or an SAP affiliate company.
 
-Licensed under the **Apache License, Version 2.0** (the "License"); you may not use this file except in compliance with the License. 
+Licensed under the **Apache License, Version 2.0** (the "License"); you may not use this file except in compliance with the License.
 
 You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.
 


### PR DESCRIPTION
This PR bumps the copyright year in the README so that it now says "2020-2021" and not only "2020".
Already done in the [Android repository](https://github.com/corona-warn-app/cwa-app-android/blob/main/README.md#licensing) & [iOS repository](https://github.com/corona-warn-app/cwa-app-ios/blob/main/README.md#licensing).